### PR TITLE
fix:check ['sort_direction'] before sorting

### DIFF
--- a/src/Repository/BaseRepository.php
+++ b/src/Repository/BaseRepository.php
@@ -66,11 +66,10 @@ class BaseRepository implements BaseRepositoryInterface
 
     protected function sort(array $parameters): Builder
     {
-        if (isset($parameters['sort_direction'])) {
-            if ($parameters['sort_direction'] !== 'ASC' || $parameters['sort_direction'] !== 'DESC') {
-                $parameters['sort_direction'] = 'DESC';
-            }
+        if (isset($parameters['sort_direction']) && in_array($parameters['sort_direction'], ['ASC', 'DESC'])) {
+            $parameters['sort_direction'] = 'DESC';
         }
+
         return $this->query
             ->orderBy($parameters['sort_by'] ?? $this->model->getKeyName(), $parameters['sort_direction'] ?? 'DESC');
     }

--- a/src/Repository/BaseRepository.php
+++ b/src/Repository/BaseRepository.php
@@ -66,8 +66,13 @@ class BaseRepository implements BaseRepositoryInterface
 
     protected function sort(array $parameters): Builder
     {
+        if (isset($parameters['sort_direction'])) {
+            if ($parameters['sort_direction'] !== 'ASC' || $parameters['sort_direction'] !== 'DESC') {
+                $parameters['sort_direction'] = 'DESC';
+            }
+        }
         return $this->query
-            ->orderBy($parameters['sort_by'] ?? $this->model->getKeyName(), $parameters['sort_direction'] ?? 'desc');
+            ->orderBy($parameters['sort_by'] ?? $this->model->getKeyName(), $parameters['sort_direction'] ?? 'DESC');
     }
 
     protected function export(array $parameters = [], array $columns = ['*']): Collection|LengthAwarePaginator|array

--- a/src/Repository/BaseRepository.php
+++ b/src/Repository/BaseRepository.php
@@ -66,7 +66,7 @@ class BaseRepository implements BaseRepositoryInterface
 
     protected function sort(array $parameters): Builder
     {
-        if (isset($parameters['sort_direction']) && in_array($parameters['sort_direction'], ['ASC', 'DESC'])) {
+        if (isset($parameters['sort_direction']) && !in_array($parameters['sort_direction'], ['ASC', 'DESC'])) {
             $parameters['sort_direction'] = 'DESC';
         }
 


### PR DESCRIPTION
if user set $parameters['sort_direction'] to something other than ASC or DESC then your your sort will rise query error